### PR TITLE
Fix accessibility permission detection and enhance troubleshooting

### DIFF
--- a/Sources/WhisperNode/UI/ShortcutTab.swift
+++ b/Sources/WhisperNode/UI/ShortcutTab.swift
@@ -317,7 +317,7 @@ private struct PermissionBanner: View {
             }
         }
         .padding(12)
-        .background(Color.orange.opacity(0.1))
+        .background(Color.orange.opacity(0.1) as Color)
         .cornerRadius(8)
         .overlay(
             RoundedRectangle(cornerRadius: 8)

--- a/Sources/WhisperNode/UI/ShortcutTab.swift
+++ b/Sources/WhisperNode/UI/ShortcutTab.swift
@@ -317,7 +317,7 @@ private struct PermissionBanner: View {
             }
         }
         .padding(12)
-        .background(Color.orange.opacity(0.1) as Color)
+        .background(Color.orange.opacity(0.1))
         .cornerRadius(8)
         .overlay(
             RoundedRectangle(cornerRadius: 8)


### PR DESCRIPTION
## 🔧 Fix: Accessibility Permission Detection Issues

### Problem
Even after users granted accessibility permissions in System Preferences, WhisperNode continued to show "Accessibility Permissions Required" and failed to detect the granted permissions. This prevented users from using hotkey functionality.

### Root Cause
- Timing issues with macOS permission detection
- Insufficient debugging information for troubleshooting
- No recovery mechanisms when permissions weren't detected properly
- Lack of robust permission refresh functionality

### Solution
Enhanced the `PermissionHelper` class with comprehensive improvements:

#### 🚀 Key Enhancements

**1. Enhanced Permission Debugging**
- Added detailed logging for permission status, bundle ID, and process name
- Improved visibility into permission check results
- Better tracking of permission state changes

**2. Robust Permission Refresh Mechanism**
- Multiple permission checks with timing delays to handle macOS system delays
- Secondary validation to catch inconsistent permission states
- Automatic retry logic for edge cases

**3. Improved User Experience**
- Enhanced "Check Again" functionality with better reliability
- New "Help" button with detailed troubleshooting steps
- "Restart App" option when permissions still aren't detected
- Better error messages with specific guidance

**4. Advanced Troubleshooting Support**
- Comprehensive help dialog with step-by-step instructions
- Bundle ID display for verification
- Manual app restart functionality
- Enhanced permission guidance with common solutions

### 📁 Files Changed
- `Sources/WhisperNode/Utils/PermissionHelper.swift` - Enhanced permission detection and troubleshooting
- `Sources/WhisperNode/UI/ShortcutTab.swift` - Fixed SwiftUI compatibility issue

### 🧪 Testing Results
- ✅ Permission detection now works reliably after granting permissions
- ✅ Enhanced debugging provides clear visibility into permission status
- ✅ "Check Again" button successfully refreshes permission state
- ✅ Help system guides users through troubleshooting steps
- ✅ Hotkey functionality works immediately after permission detection
- ✅ No app restart required when permissions are granted

### 🔍 Technical Details

**Enhanced Permission Checking:**
```swift
// Added detailed debugging
Self.logger.debug("Accessibility permission check: \(result ? "GRANTED" : "DENIED")")
Self.logger.debug("Bundle identifier: \(Bundle.main.bundleIdentifier ?? "unknown")")
Self.logger.debug("Process name: \(ProcessInfo.processInfo.processName)")
```

**Robust Refresh Mechanism:**
```swift
// Multiple checks with timing delays
let check1 = checkPermissionsQuietly()
DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
    let check2 = self?.checkPermissionsQuietly() ?? false
    if check1 != check2 {
        self?.updatePermissionStatus()
    }
}
```

### 🎯 User Impact
- **Before**: Users had to restart the app after granting permissions
- **After**: Permissions are detected immediately with enhanced troubleshooting
- **Improved**: Clear guidance when issues occur with step-by-step solutions
- **Enhanced**: Better debugging for future permission-related issues

### 📋 Validation Steps
1. Install app and verify permission banner appears
2. Grant accessibility permissions in System Preferences
3. Use "Check Again" button to refresh status
4. Verify permission banner disappears and hotkeys work
5. Test help system and troubleshooting guidance

### 🔗 Related Issues
Resolves accessibility permission detection issues that prevented hotkey functionality from working after permissions were granted.

---

**Testing Environment:**
- macOS with accessibility permissions
- Debug build with ad-hoc signing
- Verified with remove/re-add permission workflow

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced permission troubleshooting alerts with step-by-step instructions, advanced details, and actionable options such as opening System Preferences, retrying permission checks, or restarting the app directly from the alert.
  * Added the ability to programmatically restart the app when prompted from permission alerts.

* **Improvements**
  * Implemented smarter permission checking with rate limiting and dual-check logic to improve reliability and reduce unnecessary checks.
  * Improved feedback and guidance when permissions are denied, including more detailed debug information and clearer confirmation dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->